### PR TITLE
윈도우 감사 로그를 활용한 화면 보호기 실행시간 : feat : XPath쿼리문 대신 powershell에서 기본적으로 제공…

### DIFF
--- a/ScreensaverAuditor.csproj
+++ b/ScreensaverAuditor.csproj
@@ -13,6 +13,7 @@
     <PackageReference Include="ClosedXML" Version="0.104.2" />
     <PackageReference Include="System.DirectoryServices.AccountManagement" Version="7.0.0" />
     <PackageReference Include="System.Management" Version="7.0.0" />
+    <PackageReference Include="System.Management.Automation" Version="7.1.7" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
…하는 필터링 명령어 사용 https://github.com/Chuseok22/ScreensaverAuditor/issues/1

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **버그 수정**
  - 화면 보호기 이벤트 조회 시 PowerShell을 활용하여 이벤트 검색의 신뢰성과 정확성이 향상되었습니다.
  - 사용자 이름 필터링이 보다 정확하게 동작하도록 개선되었습니다.
  - 이벤트 처리 중 오류 발생 시 콘솔에 상세 로그가 출력됩니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->