### PR TITLE
20250509 #1 윈도우 감사 로그를 활용한 화면 보호기 실행시간

### DIFF
--- a/Program.cs
+++ b/Program.cs
@@ -1,9 +1,5 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Diagnostics;
+﻿using System.Diagnostics;
 using System.Diagnostics.Eventing.Reader;
-using System.IO;
-using System.Linq;
 using System.Security.Principal;
 using System.Xml;
 using ClosedXML.Excel;
@@ -331,51 +327,89 @@ namespace ScreensaverAuditor
 
             try
             {
-                // PowerShell 세션 생성
-                using var powershell = System.Management.Automation.PowerShell.Create();
+                // 임시 CSV 파일 경로
+                string tempCsv = Path.Combine(Path.GetTempPath(), $"screensaver_events_{DateTime.Now:yyyyMMddHHmmss}.csv");
 
-                // 필터 해시테이블 생성
-                var filterHashtable = new System.Collections.Hashtable
-                {
-                    ["LogName"] = "Security",
-                    ["ID"] = new int[] { 4802, 4803 },
-                    ["StartTime"] = from,
-                    ["EndTime"] = to
-                };
+                // PowerShell 명령어 구성
+                string command = $@"Get-WinEvent -FilterHashtable @{{
+                    LogName='Security'
+                    ID=4802,4803
+                    StartTime=[datetime]'{from:yyyy-MM-dd HH:mm:ss}'
+                    EndTime=[datetime]'{to:yyyy-MM-dd HH:mm:ss}'
+                }}";
 
-                // Get-WinEvent 명령 설정
-                powershell.AddCommand("Get-WinEvent")
-                          .AddParameter("FilterHashtable", filterHashtable);
-
-                // 사용자 필터 추가 (있는 경우)
                 if (user != null)
                 {
-                    powershell.AddCommand("Where-Object")
-                              .AddScript("{ $_.Message -like '*' + $UserFilter + '*' }")
-                              .AddParameter("UserFilter", user);
+                    var safeUser = user.Replace("`", "``").Replace("'", "''");
+                    command += $" | Where-Object {{ $_.Message -like '*{safeUser}*' }}";
                 }
 
-                // 출력 필드 선택
-                powershell.AddCommand("Select-Object")
-                          .AddParameter("Property", new string[] { "TimeCreated", "Id", "Message" });
+                command += " | Select-Object TimeCreated,Id,Message | Export-Csv -Path '" + tempCsv.Replace("'", "''") + "' -Encoding UTF8 -NoTypeInformation";
 
-                // 명령 실행 및 결과 처리
-                foreach (var result in powershell.Invoke())
+                // PowerShell 실행
+                var startInfo = new ProcessStartInfo
                 {
-                    var timestamp = (DateTime)result.Properties["TimeCreated"].Value;
-                    var eventId = result.Properties["Id"].Value.ToString();
-                    var message = result.Properties["Message"].Value.ToString();
+                    FileName = "powershell",
+                    Arguments = $"-NoProfile -ExecutionPolicy Bypass -Command \"{command}\"",
+                    UseShellExecute = false,
+                    RedirectStandardOutput = true,
+                    RedirectStandardError = true,
+                    CreateNoWindow = true
+                };
 
-                    string username = ExtractUsernameFromMessage(message);
+                using (var process = Process.Start(startInfo))
+                {
+                    if (process == null) throw new Exception("PowerShell 실행 실패");
 
-                    var evt = new ScreensaverEvent(
-                        timestamp,
-                        eventId,
-                        username,
-                        Environment.MachineName);
+                    // 오류 출력 확인
+                    string error = process.StandardError.ReadToEnd();
+                    process.WaitForExit();
 
-                    events.Add(evt);
-                    Console.WriteLine($"이벤트 발견: ID={evt.EventId}, 시간={evt.Timestamp:yyyy-MM-dd HH:mm:ss}, 사용자={evt.Username}");
+                    if (process.ExitCode != 0)
+                    {
+                        throw new Exception($"PowerShell 오류: {error}");
+                    }
+
+                    // CSV 파일 읽기
+                    if (File.Exists(tempCsv))
+                    {
+                        using (var reader = new StreamReader(tempCsv))
+                        {
+                            // 헤더 건너뛰기
+                            reader.ReadLine();
+
+                            using var parser = new Microsoft.VisualBasic.FileIO.TextFieldParser(reader);
+                            parser.HasFieldsEnclosedInQuotes = true;
+                            parser.SetDelimiters(",");
+                            while (!parser.EndOfData)
+                            {
+                                var parts = parser.ReadFields();
+                                if (parts?.Length >= 3)
+                                {
+                                    // CSV 데이터 파싱
+                                    var timestamp = DateTime.Parse(parts[0].Trim('"'));
+                                    var eventId = parts[1].Trim('"');
+                                    var message = parts[2].Trim('"');
+
+                                    // 사용자 이름 추출 (Message에서)
+                                    string username = ExtractUsernameFromMessage(message);
+
+                                    var evt = new ScreensaverEvent(
+                                        timestamp,
+                                        eventId,
+                                        username,
+                                        Environment.MachineName);
+
+                                    events.Add(evt);
+                                    Console.WriteLine($"이벤트 발견: ID={evt.EventId}, 시간={evt.Timestamp:yyyy-MM-dd HH:mm:ss}, 사용자={evt.Username}");
+                                }
+                            }
+                        }
+
+                        // 임시 파일 삭제
+                        try { File.Delete(tempCsv); }
+                        catch { /* 무시 */ }
+                    }
                 }
             }
             catch (Exception ex)

--- a/Program.cs
+++ b/Program.cs
@@ -434,6 +434,11 @@ namespace ScreensaverAuditor
                         {
                             if (currentEvent.Count > 0)
                             {
+                                // 메시지 라인 병합
+                                if (messageLines.Count > 0)
+                                {
+                                    currentEvent["Message"] = string.Join("\n", messageLines);
+                                }
                                 try
                                 {
                                     if (currentEvent.TryGetValue("TimeCreated", out var timeCreatedStr) &&


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **신규 기능**
  - 화면 보호기 감사 이벤트의 상세 로그(이벤트 ID, PC 이름, 메시지, 계정 정보, 세션 정보, 지속 시간 등)를 Excel로 내보내는 기능이 추가되었습니다.

- **개선 사항**
  - 이벤트 데이터가 요약 정보 대신 상세 정보로 내보내집니다.
  - 이벤트 지속 시간이 자동 계산되어 포함됩니다.
  - 외부 PowerShell 프로세스를 사용하여 이벤트를 수집하고 다국어 메시지에서 계정 정보를 추출합니다.

- **버그 수정**
  - 이벤트 분석 및 내보내기 과정의 신뢰성이 향상되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->